### PR TITLE
Ajout d'un menu interactif pour la capture

### DIFF
--- a/fonctions/calendrier_du_championnat/Fonctions_detection_Combats.py
+++ b/fonctions/calendrier_du_championnat/Fonctions_detection_Combats.py
@@ -105,7 +105,9 @@ def cliquer_croix_sortie_JGG(logger, window):
 
 # --- 4. Fonction principale d'automatisation ---
 def traiter_tous_les_combats(logger, window):
+    """Traite tous les combats détectés et renvoie le nombre de combats réalisés."""
     deja_vus = set()
+    total_traites = 0
     while True:
         combats = detecter_combats(logger, window)
         # Filtrer ceux déjà cliqués (par leur hash)
@@ -128,12 +130,15 @@ def traiter_tous_les_combats(logger, window):
                 if page and page.get("page") == "calendrier_du_championnat":
                     logger.info("Retour au calendrier, on continue.")
                     deja_vus.add(combat['hash'])
+                    total_traites += 1
                 else:
                     logger.warning("Pas revenu au calendrier, arrêt.")
-                    return
+                    return total_traites
             else:
                 logger.warning("Pas sur la page JGG après clic, arrêt.")
-                return
+                return total_traites
+
+    return total_traites
 
 # --- 5. Fonction de suivi des combats déjà cliqués (optionnel si tu veux persister l'état) ---
 # Ici, on garde tout en mémoire, mais tu peux sauvegarder la liste combats dans un fichier si besoin.

--- a/fonctions/menu.py
+++ b/fonctions/menu.py
@@ -1,0 +1,42 @@
+import keyboard
+import pymsgbox
+
+from fonctions.detection_page import detecter_page_actuelle
+from fonctions.calendrier_du_championnat.Fonctions_detection_Combats import traiter_tous_les_combats
+
+
+def afficher_aide():
+    """Affiche une fenêtre d'aide rappelant les raccourcis."""
+    message = (
+        "F1 : Afficher l'aide\n"
+        "F3 : Lancer la capture automatique\n"
+        "ESC : Quitter le programme"
+    )
+    pymsgbox.alert(message, title="Aide")
+
+
+def lancer_capture(logger, window):
+    """Lance la capture automatique des combats."""
+    page = detecter_page_actuelle(logger, window)
+    if not page or page.get("page") != "calendrier_du_championnat":
+        logger.warning("⚠️ Capture impossible : pas sur le calendrier du championnat.")
+        pymsgbox.alert(
+            "Impossible de lancer la capture : ouvrez le calendrier du championnat.",
+            title="Erreur"
+        )
+        return
+
+    total = traiter_tous_les_combats(logger, window)
+    pymsgbox.alert(
+        f"Capture terminée. Combats traités : {total}",
+        title="Fin de la capture"
+    )
+
+
+def boucle_principale(logger, window):
+    """Boucle d'attente principale pour les raccourcis clavier."""
+    logger.info("⌨️  Appuyez sur F1 pour l'aide, F3 pour lancer la capture, ESC pour quitter.")
+    keyboard.add_hotkey('f1', afficher_aide)
+    keyboard.add_hotkey('f3', lambda: lancer_capture(logger, window))
+    keyboard.wait('esc')
+    logger.info("🚪 Touche ESC détectée : arrêt du programme.")

--- a/main.py
+++ b/main.py
@@ -4,8 +4,7 @@ import time
 from configuration.log_config import setup_logger
 from configuration.bluestacks_configurator import configurer_bluestacks
 from configuration.fenetre_utils import initialiser_fenetre_bluestacks
-from fonctions.detection_page import detecter_page_actuelle
-from fonctions.calendrier_du_championnat.Fonctions_detection_Combats import traiter_tous_les_combats
+from fonctions.menu import boucle_principale
 
 logger = setup_logger()
 logger.info("▶ Lancement de la vérification BlueStacks")
@@ -25,16 +24,6 @@ logger.info("✅ Fenêtre BlueStacks prête pour les actions automatiques")
 # Attendre un peu pour s'assurer que la fenêtre est prête
 time.sleep(2)
 
-# Étape 3 : détecter la page actuelle
-page = detecter_page_actuelle(logger, window)
-if not page:
-    logger.error("❌ Page inconnue – impossible de continuer.")
-    sys.exit(1)
 
-logger.info(f"📄 Page en cours : {page}")
-
-# Étape 4 : lancer la détection et le traitement des combats si on est sur le calendrier
-if page.get("page") == "calendrier_du_championnat":
-    traiter_tous_les_combats(logger, window)
-else:
-    logger.warning("⚠️ Pas sur la page calendrier du championnat, automation des combats non lancée.")
+# Boucle principale d'interaction
+boucle_principale(logger, window)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "python-dotenv==1.1.0",
     "pytweening==1.2.0",
     "win32-setctime==1.2.0",
+    "keyboard==0.13.5",
 ]
 
 [tool.uv]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pyscreeze==1.0.1
 python-dotenv==1.1.0
 pytweening==1.2.0
 win32-setctime==1.2.0
+keyboard==0.13.5


### PR DESCRIPTION
## Summary
- créer `fonctions/menu.py` avec boucle principale et aide
- améliorer `traiter_tous_les_combats` pour retourner le nombre de combats
- intégrer le menu dans `main.py`
- ajouter la dépendance `keyboard`

## Testing
- `python -m py_compile main.py fonctions/menu.py fonctions/calendrier_du_championnat/Fonctions_detection_Combats.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684abe6aa1ec83329998d845ac19e4a4