### PR TITLE
Add runtime debug toggle and improve logging

### DIFF
--- a/configuration/log_config.py
+++ b/configuration/log_config.py
@@ -53,3 +53,12 @@ def setup_logger():
         logger.addHandler(stream_handler)
 
     return logger
+
+
+def toggle_debug(logger: logging.Logger) -> None:
+    """Basculer dynamiquement entre les niveaux INFO et DEBUG."""
+    new_level = logging.DEBUG if logger.level != logging.DEBUG else logging.INFO
+    logger.setLevel(new_level)
+    for handler in logger.handlers:
+        handler.setLevel(new_level)
+    logger.info("Nouveau niveau de log : %s", logging.getLevelName(new_level))

--- a/fonctions/calendrier_du_championnat/Fonctions_detection_Combats.py
+++ b/fonctions/calendrier_du_championnat/Fonctions_detection_Combats.py
@@ -17,6 +17,7 @@ def detecter_combats(logger, window):
     Détecte tous les combats à l'écran en cherchant les textes 'Victoire', 'Défaite', 'Égalité'.
     Retourne une liste de dicts : { 'id': int, 'coord': (x, y), 'type': str, 'clicked': False }
     """
+    logger.debug("Début de la détection des combats")
     templates = {
         "victoire": os.path.join("templates", "calendrier_du_championnat", "victoire_cdc.png"),
         "defaite": os.path.join("templates", "calendrier_du_championnat", "defaite_cdc.png"),
@@ -106,6 +107,7 @@ def cliquer_croix_sortie_JGG(logger, window):
 # --- 4. Fonction principale d'automatisation ---
 def traiter_tous_les_combats(logger, window):
     """Traite tous les combats détectés et renvoie le nombre de combats réalisés."""
+    logger.debug("Démarrage du traitement de tous les combats")
     deja_vus = set()
     total_traites = 0
     while True:
@@ -138,6 +140,7 @@ def traiter_tous_les_combats(logger, window):
                 logger.warning("Pas sur la page JGG après clic, arrêt.")
                 return total_traites
 
+    logger.info("Nombre total de combats traités : %s", total_traites)
     return total_traites
 
 # --- 5. Fonction de suivi des combats déjà cliqués (optionnel si tu veux persister l'état) ---

--- a/fonctions/detection_page.py
+++ b/fonctions/detection_page.py
@@ -90,6 +90,7 @@ def detecter_limites_scroll(logger, screenshot_cv, dossier_limites):
     return rect
 
 def detecter_page_actuelle(logger, window):
+    logger.debug("Détection de la page en cours")
     if not window:
         logger.error("❌ Impossible de détecter la page : fenêtre BlueStacks non trouvée.")
         return None
@@ -134,8 +135,10 @@ def detecter_page_actuelle(logger, window):
     if "limites" in config:
         dossier_limites = os.path.join(TEMPLATES_PAGES_DIR, config["limites"]["dossier"])
         limites_scroll = detecter_limites_scroll(logger, screenshot_cv, dossier_limites)
-    return {
+    resultat = {
         "page": page_detectee,
         "onglet": onglet_actif,
         "limites": limites_scroll,
     }
+    logger.debug("Page détectée: %s", resultat)
+    return resultat

--- a/fonctions/menu.py
+++ b/fonctions/menu.py
@@ -1,15 +1,20 @@
 import keyboard
 import pymsgbox
 
+from configuration.log_config import toggle_debug
+
 from fonctions.detection_page import detecter_page_actuelle
 from fonctions.calendrier_du_championnat.Fonctions_detection_Combats import traiter_tous_les_combats
 
 
-def afficher_aide():
+def afficher_aide(logger=None):
     """Affiche une fenêtre d'aide rappelant les raccourcis."""
+    if logger:
+        logger.info("Affichage de l'aide utilisateur")
     message = (
         "F1 : Afficher l'aide\n"
         "F3 : Lancer la capture automatique\n"
+        "F9 : Basculer le mode debug\n"
         "ESC : Quitter le programme"
     )
     pymsgbox.alert(message, title="Aide")
@@ -17,6 +22,7 @@ def afficher_aide():
 
 def lancer_capture(logger, window):
     """Lance la capture automatique des combats."""
+    logger.info("Demande de lancement de la capture")
     page = detecter_page_actuelle(logger, window)
     if not page or page.get("page") != "calendrier_du_championnat":
         logger.warning("⚠️ Capture impossible : pas sur le calendrier du championnat.")
@@ -35,8 +41,11 @@ def lancer_capture(logger, window):
 
 def boucle_principale(logger, window):
     """Boucle d'attente principale pour les raccourcis clavier."""
-    logger.info("⌨️  Appuyez sur F1 pour l'aide, F3 pour lancer la capture, ESC pour quitter.")
-    keyboard.add_hotkey('f1', afficher_aide)
+    logger.info(
+        "⌨️  Appuyez sur F1 pour l'aide, F3 pour lancer la capture, F9 pour le debug, ESC pour quitter."
+    )
+    keyboard.add_hotkey('f1', lambda: afficher_aide(logger))
     keyboard.add_hotkey('f3', lambda: lancer_capture(logger, window))
+    keyboard.add_hotkey('f9', lambda: toggle_debug(logger))
     keyboard.wait('esc')
     logger.info("🚪 Touche ESC détectée : arrêt du programme.")


### PR DESCRIPTION
## Summary
- add `toggle_debug` helper to switch logging levels on the fly
- wire F9 key to toggle debug mode in the menu
- log actions in menu, detection routines and combat handling

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac1b47a988332a4a37e5766c0a6bc