### PR TITLE
Add overlay toggle without screenshot logic

### DIFF
--- a/fonctions/menu.py
+++ b/fonctions/menu.py
@@ -2,6 +2,7 @@ import keyboard
 import pymsgbox
 
 from configuration.log_config import toggle_debug
+from fonctions.overlay import Overlay
 
 from fonctions.detection_page import detecter_page_actuelle
 from fonctions.calendrier_du_championnat.Fonctions_detection_Combats import traiter_tous_les_combats
@@ -15,14 +16,16 @@ def afficher_aide(logger=None):
         "F1 : Afficher l'aide\n"
         "F3 : Lancer la capture automatique\n"
         "F9 : Basculer le mode debug\n"
+        "F8 : Afficher/Masquer l'overlay\n"
         "ESC : Quitter le programme"
     )
     pymsgbox.alert(message, title="Aide")
 
 
-def lancer_capture(logger, window):
+def lancer_capture(logger, window, overlay: Overlay):
     """Lance la capture automatique des combats."""
     logger.info("Demande de lancement de la capture")
+    overlay.set_phase("Détection de la page")
     page = detecter_page_actuelle(logger, window)
     if not page or page.get("page") != "calendrier_du_championnat":
         logger.warning("⚠️ Capture impossible : pas sur le calendrier du championnat.")
@@ -32,20 +35,24 @@ def lancer_capture(logger, window):
         )
         return
 
+    overlay.set_phase("Traitement des combats")
     total = traiter_tous_les_combats(logger, window)
+    overlay.set_phase("En attente")
     pymsgbox.alert(
         f"Capture terminée. Combats traités : {total}",
         title="Fin de la capture"
     )
 
 
-def boucle_principale(logger, window):
+def boucle_principale(logger, window, overlay: Overlay):
     """Boucle d'attente principale pour les raccourcis clavier."""
     logger.info(
         "⌨️  Appuyez sur F1 pour l'aide, F3 pour lancer la capture, F9 pour le debug, ESC pour quitter."
     )
     keyboard.add_hotkey('f1', lambda: afficher_aide(logger))
-    keyboard.add_hotkey('f3', lambda: lancer_capture(logger, window))
+    overlay.set_phase("En attente")
+    keyboard.add_hotkey('f3', lambda: lancer_capture(logger, window, overlay))
+    keyboard.add_hotkey('f8', lambda: overlay.toggle())
     keyboard.add_hotkey('f9', lambda: toggle_debug(logger))
     keyboard.wait('esc')
     logger.info("🚪 Touche ESC détectée : arrêt du programme.")

--- a/fonctions/overlay.py
+++ b/fonctions/overlay.py
@@ -1,0 +1,56 @@
+import threading
+import tkinter as tk
+
+class Overlay:
+    """Petite fenêtre superposée indiquant l'état courant."""
+
+    def __init__(self, window, width=240, height=60):
+        self.window = window
+        self.width = width
+        self.height = height
+        self.visible = True
+
+        self.root = tk.Tk()
+        self.root.overrideredirect(True)
+        self.root.attributes("-topmost", True)
+        self.root.attributes("-alpha", 0.85)
+
+        self.phase_var = tk.StringVar(value="Initialisation")
+        self.action_var = tk.StringVar(value="")
+
+        frame = tk.Frame(self.root, bg="black")
+        frame.pack(fill="both", expand=True)
+        tk.Label(frame, textvariable=self.phase_var, fg="white", bg="black", font=("Arial", 12, "bold")).pack(fill="x", padx=5, pady=(4, 0))
+        tk.Label(frame, textvariable=self.action_var, fg="white", bg="black", font=("Arial", 10)).pack(fill="x", padx=5, pady=(0, 4))
+
+        self.update_position()
+        threading.Thread(target=self.root.mainloop, daemon=True).start()
+
+    def update_position(self):
+        if self.window:
+            x = self.window.left + self.window.width - self.width
+            y = self.window.top
+            self.root.geometry(f"{self.width}x{self.height}+{x}+{y}")
+        self.root.after(500, self.update_position)
+
+    def set_phase(self, text: str):
+        self.phase_var.set(text)
+
+    def set_action(self, text: str):
+        self.action_var.set(text)
+
+    def hide(self):
+        if self.visible:
+            self.root.withdraw()
+            self.visible = False
+
+    def show(self):
+        if not self.visible:
+            self.root.deiconify()
+            self.visible = True
+
+    def toggle(self):
+        if self.visible:
+            self.hide()
+        else:
+            self.show()

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from configuration.log_config import setup_logger
 from configuration.bluestacks_configurator import configurer_bluestacks
 from configuration.fenetre_utils import initialiser_fenetre_bluestacks
 from fonctions.menu import boucle_principale
+from fonctions.overlay import Overlay
 
 logger = setup_logger()
 logger.info("▶ Lancement de la vérification BlueStacks")
@@ -24,6 +25,6 @@ logger.info("✅ Fenêtre BlueStacks prête pour les actions automatiques")
 # Attendre un peu pour s'assurer que la fenêtre est prête
 time.sleep(2)
 
-
+overlay = Overlay(window)
 # Boucle principale d'interaction
-boucle_principale(logger, window)
+boucle_principale(logger, window, overlay)


### PR DESCRIPTION
## Summary
- remove overlay hooks from detection routines
- update menu to manage overlay toggle and phases
- keep simple professional overlay UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ad41e9ab083329e087f01d2e93a85