### PR TITLE
Fix overlay threading with Tkinter

### DIFF
--- a/fonctions/menu.py
+++ b/fonctions/menu.py
@@ -56,3 +56,4 @@ def boucle_principale(logger, window, overlay: Overlay):
     keyboard.add_hotkey('f9', lambda: toggle_debug(logger))
     keyboard.wait('esc')
     logger.info("🚪 Touche ESC détectée : arrêt du programme.")
+    overlay.stop()

--- a/fonctions/overlay.py
+++ b/fonctions/overlay.py
@@ -1,4 +1,3 @@
-import threading
 import tkinter as tk
 
 class Overlay:
@@ -24,7 +23,14 @@ class Overlay:
         tk.Label(frame, textvariable=self.action_var, fg="white", bg="black", font=("Arial", 10)).pack(fill="x", padx=5, pady=(0, 4))
 
         self.update_position()
-        threading.Thread(target=self.root.mainloop, daemon=True).start()
+
+    def start(self):
+        """Démarre la boucle Tk de l'overlay."""
+        self.root.mainloop()
+
+    def stop(self):
+        """Arrête la boucle Tk en toute sécurité."""
+        self.root.after(0, self.root.quit)
 
     def update_position(self):
         if self.window:
@@ -34,19 +40,19 @@ class Overlay:
         self.root.after(500, self.update_position)
 
     def set_phase(self, text: str):
-        self.phase_var.set(text)
+        self.root.after(0, self.phase_var.set, text)
 
     def set_action(self, text: str):
-        self.action_var.set(text)
+        self.root.after(0, self.action_var.set, text)
 
     def hide(self):
         if self.visible:
-            self.root.withdraw()
+            self.root.after(0, self.root.withdraw)
             self.visible = False
 
     def show(self):
         if not self.visible:
-            self.root.deiconify()
+            self.root.after(0, self.root.deiconify)
             self.visible = True
 
     def toggle(self):

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import sys
 import time
+import threading
 
 from configuration.log_config import setup_logger
 from configuration.bluestacks_configurator import configurer_bluestacks
@@ -26,5 +27,13 @@ logger.info("✅ Fenêtre BlueStacks prête pour les actions automatiques")
 time.sleep(2)
 
 overlay = Overlay(window)
-# Boucle principale d'interaction
-boucle_principale(logger, window, overlay)
+
+# Boucle principale d'interaction exécutée dans un thread séparé
+threading.Thread(
+    target=boucle_principale,
+    args=(logger, window, overlay),
+    daemon=True,
+).start()
+
+# L'overlay doit tourner dans le thread principal
+overlay.start()


### PR DESCRIPTION
## Summary
- run Tkinter mainloop in main thread
- move keyboard controls to a separate thread and stop overlay on ESC
- update overlay methods to be thread-safe

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2a5d0fe083329b41c838767af546