### PR TITLE
Add rectangle detection for defeat results

### DIFF
--- a/configuration/config.py
+++ b/configuration/config.py
@@ -17,3 +17,4 @@ PAGE_MATCH_THRESHOLD = 0.94      # seuil pour matchTemplate sur les pages
 TAB_MATCH_THRESHOLD = 0.85       # seuil pour matchTemplate sur les onglets
 LIMIT_MATCH_THRESHOLD = 0.80     # seuil pour les limites (scroll)
 COMBAT_MATCH_THRESHOLD = 0.99    # seuil pour la détection des combats
+COMBAT_RECT_MATCH_THRESHOLD = 0.80  # seuil pour la détection des rectangles de défaite


### PR DESCRIPTION
## Summary
- add `COMBAT_RECT_MATCH_THRESHOLD` constant
- detect defeat results using the four edge images instead of a single template
- compute patch hash around the detected rectangle centre

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2e5e64c48332826aacc19e172542