### PR TITLE
Add F12 template recapture hotkey

### DIFF
--- a/fonctions/menu.py
+++ b/fonctions/menu.py
@@ -21,6 +21,7 @@ def afficher_aide(logger=None):
         "F12 : Reprendre les templates manuellement\n"
         "F9 : Basculer le mode debug\n"
         "F8 : Afficher/Masquer l'overlay\n"
+        "CTRL + Clic droit : Capturer le template\n"
         "P : Passer le template courant\n"
         "ESC : Quitter le programme"
     )
@@ -52,7 +53,7 @@ def lancer_capture(logger, window, overlay: Overlay):
 def boucle_principale(logger, window, overlay: Overlay):
     """Boucle d'attente principale pour les raccourcis clavier."""
     logger.info(
-        "⌨️  Appuyez sur F1 pour l'aide, F3 pour lancer la capture, F12 pour la recapture, F9 pour le debug, ESC pour quitter."
+        "⌨️  Appuyez sur F1 pour l'aide, F3 pour lancer la capture, F12 pour la recapture (CTRL + clic droit), F9 pour le debug, ESC pour quitter."
     )
     keyboard.add_hotkey('f1', lambda: afficher_aide(logger))
     overlay.set_phase("En attente")

--- a/fonctions/menu.py
+++ b/fonctions/menu.py
@@ -18,8 +18,10 @@ def afficher_aide(logger=None):
     message = (
         "F1 : Afficher l'aide\n"
         "F3 : Lancer la capture automatique\n"
+        "F12 : Reprendre les templates manuellement\n"
         "F9 : Basculer le mode debug\n"
         "F8 : Afficher/Masquer l'overlay\n"
+        "P : Passer le template courant\n"
         "ESC : Quitter le programme"
     )
     pymsgbox.alert(message, title="Aide")
@@ -50,7 +52,7 @@ def lancer_capture(logger, window, overlay: Overlay):
 def boucle_principale(logger, window, overlay: Overlay):
     """Boucle d'attente principale pour les raccourcis clavier."""
     logger.info(
-        "⌨️  Appuyez sur F1 pour l'aide, F3 pour lancer la capture, F9 pour le debug, ESC pour quitter."
+        "⌨️  Appuyez sur F1 pour l'aide, F3 pour lancer la capture, F12 pour la recapture, F9 pour le debug, ESC pour quitter."
     )
     keyboard.add_hotkey('f1', lambda: afficher_aide(logger))
     overlay.set_phase("En attente")

--- a/fonctions/menu.py
+++ b/fonctions/menu.py
@@ -5,7 +5,7 @@ import pymsgbox
 
 from configuration.log_config import toggle_debug
 from fonctions.overlay import Overlay
-from fonctions.template_recorder import capturer_templates
+from fonctions.template_recorder import capturer_templates, lister_tous_les_templates
 
 from fonctions.detection_page import detecter_page_actuelle
 from fonctions.calendrier_du_championnat.Fonctions_detection_Combats import traiter_tous_les_combats
@@ -76,18 +76,5 @@ def boucle_principale(logger, window, overlay: Overlay):
     overlay.stop()
 
 def lancer_recapture(logger, window, overlay: Overlay):
-    templates = [
-        {
-            "path": os.path.join("templates", "calendrier_du_championnat", "victoire_cdc.png"),
-            "description": "Victoire CDC",
-        },
-        {
-            "path": os.path.join("templates", "calendrier_du_championnat", "egalite_cdc.png"),
-            "description": "Egalite CDC",
-        },
-        {
-            "path": os.path.join("templates", "calendrier_du_championnat", "defaite_cdc.png"),
-            "description": "Defaite CDC",
-        },
-    ]
+    templates = lister_tous_les_templates()
     capturer_templates(logger, window, overlay, templates)

--- a/fonctions/menu.py
+++ b/fonctions/menu.py
@@ -1,8 +1,11 @@
+import os
+import time
 import keyboard
 import pymsgbox
 
 from configuration.log_config import toggle_debug
 from fonctions.overlay import Overlay
+from fonctions.template_recorder import capturer_templates
 
 from fonctions.detection_page import detecter_page_actuelle
 from fonctions.calendrier_du_championnat.Fonctions_detection_Combats import traiter_tous_les_combats
@@ -52,8 +55,36 @@ def boucle_principale(logger, window, overlay: Overlay):
     keyboard.add_hotkey('f1', lambda: afficher_aide(logger))
     overlay.set_phase("En attente")
     keyboard.add_hotkey('f3', lambda: lancer_capture(logger, window, overlay))
+    keyboard.add_hotkey('f12', lambda: lancer_recapture(logger, window, overlay))
     keyboard.add_hotkey('f8', lambda: overlay.toggle())
     keyboard.add_hotkey('f9', lambda: toggle_debug(logger))
-    keyboard.wait('esc')
+    running = True
+
+    def stop_program():
+        nonlocal running
+        running = False
+
+    keyboard.add_hotkey('esc', stop_program)
+
+    while running:
+        time.sleep(0.1)
+
     logger.info("🚪 Touche ESC détectée : arrêt du programme.")
     overlay.stop()
+
+def lancer_recapture(logger, window, overlay: Overlay):
+    templates = [
+        {
+            "path": os.path.join("templates", "calendrier_du_championnat", "victoire_cdc.png"),
+            "description": "Victoire CDC",
+        },
+        {
+            "path": os.path.join("templates", "calendrier_du_championnat", "egalite_cdc.png"),
+            "description": "Egalite CDC",
+        },
+        {
+            "path": os.path.join("templates", "calendrier_du_championnat", "defaite_cdc.png"),
+            "description": "Defaite CDC",
+        },
+    ]
+    capturer_templates(logger, window, overlay, templates)

--- a/fonctions/template_recorder.py
+++ b/fonctions/template_recorder.py
@@ -1,0 +1,75 @@
+import os
+import time
+from typing import List, Dict
+
+import keyboard as kb
+import pyautogui
+from PIL import Image
+from pynput import mouse, keyboard as pynput_keyboard
+
+from fonctions.overlay import Overlay
+
+
+def capturer_templates(logger, window, overlay: Overlay, templates: List[Dict[str, str]]):
+    """Lance la capture manuelle d'une liste de templates.
+
+    Chaque élément de ``templates`` doit être un dict avec les clés ``path`` et
+    ``description``. Les captures sont réalisées aux dimensions du premier
+    fichier existant de la liste. L'utilisateur doit maintenir la touche CTRL et
+    cliquer avec le bouton gauche pour prendre la capture à la position de la
+    souris. Appuyer sur ESC interrompt la séquence.
+    """
+    if not templates:
+        logger.warning("Aucun template à capturer")
+        return
+
+    # Détermination de la taille à utiliser
+    width = height = None
+    for tpl in templates:
+        if os.path.exists(tpl["path"]):
+            img = Image.open(tpl["path"])
+            width, height = img.size
+            break
+    if width is None:
+        width, height = 100, 100
+
+    overlay.set_phase("Capture templates")
+    index = 0
+    stop_capture = False
+
+    def on_click(x, y, button, pressed):
+        nonlocal index, stop_capture
+        if stop_capture:
+            return False
+        if not pressed:
+            return
+        if button != mouse.Button.left:
+            return
+        if not kb.is_pressed('ctrl'):
+            return
+        # Capture de la zone
+        left = int(x - width / 2)
+        top = int(y - height / 2)
+        screenshot = pyautogui.screenshot(region=(left, top, width, height))
+        os.makedirs(os.path.dirname(templates[index]["path"]), exist_ok=True)
+        screenshot.save(templates[index]["path"])
+        logger.info(f"Template sauvegardé : {templates[index]['path']}")
+        index += 1
+        if index >= len(templates):
+            stop_capture = True
+            return False
+        overlay.set_action(templates[index]["description"])
+
+    def on_press(key):
+        nonlocal stop_capture
+        if key == pynput_keyboard.Key.esc:
+            stop_capture = True
+            return False
+
+    overlay.set_action(templates[index]["description"])
+    with mouse.Listener(on_click=on_click) as listener, pynput_keyboard.Listener(on_press=on_press):
+        while not stop_capture:
+            time.sleep(0.1)
+
+    overlay.set_phase("En attente")
+    overlay.set_action("")

--- a/fonctions/template_recorder.py
+++ b/fonctions/template_recorder.py
@@ -1,5 +1,6 @@
 import os
 import time
+import threading
 from typing import List, Dict
 
 import keyboard as kb
@@ -39,8 +40,11 @@ def capturer_templates(logger, window, overlay: Overlay, templates: List[Dict[st
     index = 0
     stop_capture = False
 
-    # Petite fenêtre affichant le cadre de capture lorsque CTRL est maintenu
+    cursor_win = None
+    create_event = threading.Event()
+
     def create_cursor_window():
+        nonlocal cursor_win
         win = tk.Toplevel(overlay.root)
         win.overrideredirect(True)
         win.attributes("-topmost", True)
@@ -50,9 +54,11 @@ def capturer_templates(logger, window, overlay: Overlay, templates: List[Dict[st
         canvas.pack()
         canvas.create_rectangle(0, 0, width - 1, height - 1, outline="red", width=2)
         win.withdraw()
-        return win
+        cursor_win = win
+        create_event.set()
 
-    cursor_win = create_cursor_window()
+    overlay.root.after(0, create_cursor_window)
+    create_event.wait()
 
     def capture_current(_event=None):
         nonlocal index, stop_capture
@@ -76,7 +82,7 @@ def capturer_templates(logger, window, overlay: Overlay, templates: List[Dict[st
         cursor_win.deiconify()
         return "break"
 
-    cursor_win.bind("<Button-1>", capture_current)
+    overlay.root.after(0, lambda: cursor_win.bind("<Button-1>", capture_current))
 
     def on_press(key):
         nonlocal stop_capture, index

--- a/fonctions/template_recorder.py
+++ b/fonctions/template_recorder.py
@@ -41,20 +41,30 @@ def capturer_templates(logger, window, overlay: Overlay, templates: List[Dict[st
     stop_capture = False
 
     cursor_win = None
+    cursor_canvas = None
+    cursor_rect = None
     create_event = threading.Event()
 
     def create_cursor_window():
-        nonlocal cursor_win
+        nonlocal cursor_win, cursor_canvas, cursor_rect
         win = tk.Toplevel(overlay.root)
         win.overrideredirect(True)
         win.attributes("-topmost", True)
         win.attributes("-transparentcolor", "magenta")
         win.configure(bg="magenta")
-        canvas = tk.Canvas(win, width=width, height=height, highlightthickness=0, bg="magenta")
+        win.geometry(f"{window.width}x{window.height}+{window.left}+{window.top}")
+
+        canvas = tk.Canvas(win, width=window.width, height=window.height,
+                           highlightthickness=0, bg="magenta")
         canvas.pack()
-        canvas.create_rectangle(0, 0, width - 1, height - 1, outline="red", width=2)
-        win.withdraw()
+        rect = canvas.create_rectangle(0, 0, width, height,
+                                       outline="red", width=2)
+        canvas.itemconfigure(rect, state="hidden")
+
         cursor_win = win
+        cursor_canvas = canvas
+        cursor_rect = rect
+        win.withdraw()
         create_event.set()
 
     overlay.root.after(0, create_cursor_window)
@@ -79,7 +89,6 @@ def capturer_templates(logger, window, overlay: Overlay, templates: List[Dict[st
             stop_capture = True
         else:
             overlay.set_action(templates[index]["description"])
-        cursor_win.deiconify()
         return "break"
 
     overlay.root.after(0, lambda: cursor_win.bind("<Button-1>", capture_current))
@@ -108,9 +117,19 @@ def capturer_templates(logger, window, overlay: Overlay, templates: List[Dict[st
             x, y = pyautogui.position()
             left = int(x - width / 2)
             top = int(y - height / 2)
-            cursor_win.geometry(f"{width}x{height}+{left}+{top}")
+            # position relative to the BlueStacks window
+            rel_x = left - window.left
+            rel_y = top - window.top
+            cursor_canvas.coords(cursor_rect,
+                                rel_x,
+                                rel_y,
+                                rel_x + width,
+                                rel_y + height)
+            cursor_canvas.itemconfigure(cursor_rect, state="normal")
+            cursor_win.geometry(f"{window.width}x{window.height}+{window.left}+{window.top}")
             cursor_win.deiconify()
         else:
+            cursor_canvas.itemconfigure(cursor_rect, state="hidden")
             cursor_win.withdraw()
         overlay.root.after(30, update_cursor)
 

--- a/fonctions/template_recorder.py
+++ b/fonctions/template_recorder.py
@@ -5,7 +5,7 @@ from typing import List, Dict
 import keyboard as kb
 import pyautogui
 from PIL import Image
-from pynput import mouse, keyboard as pynput_keyboard
+from pynput import keyboard as pynput_keyboard
 import tkinter as tk
 
 from fonctions.overlay import Overlay
@@ -53,19 +53,16 @@ def capturer_templates(logger, window, overlay: Overlay, templates: List[Dict[st
 
     cursor_win = create_cursor_window()
 
-    def on_click(x, y, button, pressed):
+    def capture_current(_event=None):
         nonlocal index, stop_capture
-        if stop_capture:
-            return False
-        if not pressed:
-            return
-        if button != mouse.Button.left:
-            return
-        if not kb.is_pressed('ctrl'):
-            return
-        # Capture de la zone
+        if stop_capture or not kb.is_pressed('ctrl'):
+            return "break"
+        x, y = pyautogui.position()
         left = int(x - width / 2)
         top = int(y - height / 2)
+        cursor_win.withdraw()
+        overlay.root.update_idletasks()
+        time.sleep(0.05)
         screenshot = pyautogui.screenshot(region=(left, top, width, height))
         os.makedirs(os.path.dirname(templates[index]["path"]), exist_ok=True)
         screenshot.save(templates[index]["path"])
@@ -73,8 +70,12 @@ def capturer_templates(logger, window, overlay: Overlay, templates: List[Dict[st
         index += 1
         if index >= len(templates):
             stop_capture = True
-            return False
-        overlay.set_action(templates[index]["description"])
+        else:
+            overlay.set_action(templates[index]["description"])
+        cursor_win.deiconify()
+        return "break"
+
+    cursor_win.bind("<Button-1>", capture_current)
 
     def on_press(key):
         nonlocal stop_capture
@@ -99,7 +100,7 @@ def capturer_templates(logger, window, overlay: Overlay, templates: List[Dict[st
     overlay.set_action(templates[index]["description"])
     overlay.root.after(0, update_cursor)
 
-    with mouse.Listener(on_click=on_click) as listener, pynput_keyboard.Listener(on_press=on_press):
+    with pynput_keyboard.Listener(on_press=on_press):
         while not stop_capture:
             time.sleep(0.1)
 

--- a/fonctions/template_recorder.py
+++ b/fonctions/template_recorder.py
@@ -6,7 +6,7 @@ from typing import List, Dict
 import keyboard as kb
 import pyautogui
 from PIL import Image
-from pynput import keyboard as pynput_keyboard
+from pynput import keyboard as pynput_keyboard, mouse as pynput_mouse
 import tkinter as tk
 
 from fonctions.overlay import Overlay
@@ -18,8 +18,8 @@ def capturer_templates(logger, window, overlay: Overlay, templates: List[Dict[st
     Chaque élément de ``templates`` doit être un dict avec les clés ``path`` et
     ``description``. Les captures sont réalisées aux dimensions du premier
     fichier existant de la liste. L'utilisateur doit maintenir la touche CTRL et
-    cliquer avec le bouton gauche pour prendre la capture à la position de la
-    souris. Appuyer sur ``p`` passe au template suivant sans capture. Appuyer sur
+    cliquer **droit** pour prendre la capture à la position de la souris.
+    Appuyer sur ``p`` passe au template suivant sans capture. Appuyer sur
     ESC interrompt la séquence.
     """
     if not templates:
@@ -36,7 +36,7 @@ def capturer_templates(logger, window, overlay: Overlay, templates: List[Dict[st
     if width is None:
         width, height = 100, 100
 
-    overlay.set_phase("Capture templates")
+    overlay.set_phase("Capture templates (CTRL + clic droit)")
     index = 0
     stop_capture = False
 
@@ -91,7 +91,15 @@ def capturer_templates(logger, window, overlay: Overlay, templates: List[Dict[st
             overlay.set_action(templates[index]["description"])
         return "break"
 
-    overlay.root.after(0, lambda: cursor_win.bind("<Button-1>", capture_current))
+    # La capture est déclenchée par un clic droit global lorsque CTRL est enfoncé
+    def on_click(x, y, button, pressed):
+        if (
+            pressed
+            and button == pynput_mouse.Button.right
+            and kb.is_pressed("ctrl")
+        ):
+            capture_current()
+
 
     def on_press(key):
         nonlocal stop_capture, index
@@ -136,7 +144,8 @@ def capturer_templates(logger, window, overlay: Overlay, templates: List[Dict[st
     overlay.set_action(templates[index]["description"])
     overlay.root.after(0, update_cursor)
 
-    with pynput_keyboard.Listener(on_press=on_press):
+    with pynput_keyboard.Listener(on_press=on_press) as key_listener, \
+            pynput_mouse.Listener(on_click=on_click) as mouse_listener:
         while not stop_capture:
             time.sleep(0.1)
 

--- a/fonctions/template_recorder.py
+++ b/fonctions/template_recorder.py
@@ -12,6 +12,21 @@ import tkinter as tk
 from fonctions.overlay import Overlay
 
 
+def lister_tous_les_templates(root_dir: str = "templates") -> List[Dict[str, str]]:
+    """Retourne la liste de tous les templates PNG du projet.
+
+    Chaque élément contient le chemin absolu et une description relative
+    au dossier ``root_dir``.
+    """
+    templates = []
+    for dirpath, _, filenames in os.walk(root_dir):
+        for filename in sorted(f for f in filenames if f.lower().endswith(".png")):
+            path = os.path.join(dirpath, filename)
+            description = os.path.relpath(path, root_dir)
+            templates.append({"path": path, "description": description})
+    return sorted(templates, key=lambda t: t["description"])
+
+
 def capturer_templates(logger, window, overlay: Overlay, templates: List[Dict[str, str]]):
     """Lance la capture manuelle d'une liste de templates.
 

--- a/fonctions/template_recorder.py
+++ b/fonctions/template_recorder.py
@@ -6,6 +6,7 @@ import keyboard as kb
 import pyautogui
 from PIL import Image
 from pynput import mouse, keyboard as pynput_keyboard
+import tkinter as tk
 
 from fonctions.overlay import Overlay
 
@@ -37,6 +38,21 @@ def capturer_templates(logger, window, overlay: Overlay, templates: List[Dict[st
     index = 0
     stop_capture = False
 
+    # Petite fenêtre affichant le cadre de capture lorsque CTRL est maintenu
+    def create_cursor_window():
+        win = tk.Toplevel(overlay.root)
+        win.overrideredirect(True)
+        win.attributes("-topmost", True)
+        win.attributes("-transparentcolor", "magenta")
+        win.configure(bg="magenta")
+        canvas = tk.Canvas(win, width=width, height=height, highlightthickness=0, bg="magenta")
+        canvas.pack()
+        canvas.create_rectangle(0, 0, width - 1, height - 1, outline="red", width=2)
+        win.withdraw()
+        return win
+
+    cursor_win = create_cursor_window()
+
     def on_click(x, y, button, pressed):
         nonlocal index, stop_capture
         if stop_capture:
@@ -66,10 +82,27 @@ def capturer_templates(logger, window, overlay: Overlay, templates: List[Dict[st
             stop_capture = True
             return False
 
+    def update_cursor():
+        if stop_capture:
+            cursor_win.withdraw()
+            return
+        if kb.is_pressed('ctrl'):
+            x, y = pyautogui.position()
+            left = int(x - width / 2)
+            top = int(y - height / 2)
+            cursor_win.geometry(f"{width}x{height}+{left}+{top}")
+            cursor_win.deiconify()
+        else:
+            cursor_win.withdraw()
+        overlay.root.after(30, update_cursor)
+
     overlay.set_action(templates[index]["description"])
+    overlay.root.after(0, update_cursor)
+
     with mouse.Listener(on_click=on_click) as listener, pynput_keyboard.Listener(on_press=on_press):
         while not stop_capture:
             time.sleep(0.1)
 
     overlay.set_phase("En attente")
     overlay.set_action("")
+    overlay.root.after(0, cursor_win.destroy)

--- a/fonctions/template_recorder.py
+++ b/fonctions/template_recorder.py
@@ -18,7 +18,8 @@ def capturer_templates(logger, window, overlay: Overlay, templates: List[Dict[st
     ``description``. Les captures sont réalisées aux dimensions du premier
     fichier existant de la liste. L'utilisateur doit maintenir la touche CTRL et
     cliquer avec le bouton gauche pour prendre la capture à la position de la
-    souris. Appuyer sur ESC interrompt la séquence.
+    souris. Appuyer sur ``p`` passe au template suivant sans capture. Appuyer sur
+    ESC interrompt la séquence.
     """
     if not templates:
         logger.warning("Aucun template à capturer")
@@ -78,10 +79,20 @@ def capturer_templates(logger, window, overlay: Overlay, templates: List[Dict[st
     cursor_win.bind("<Button-1>", capture_current)
 
     def on_press(key):
-        nonlocal stop_capture
+        nonlocal stop_capture, index
         if key == pynput_keyboard.Key.esc:
             stop_capture = True
             return False
+        try:
+            if key.char and key.char.lower() == 'p':
+                logger.info("Template ignoré")
+                index += 1
+                if index >= len(templates):
+                    stop_capture = True
+                else:
+                    overlay.set_action(templates[index]["description"])
+        except AttributeError:
+            pass
 
     def update_cursor():
         if stop_capture:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pytweening==1.2.0",
     "win32-setctime==1.2.0",
     "keyboard==0.13.5",
+    "pynput==1.7.6",
 ]
 
 [tool.uv]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ python-dotenv==1.1.0
 pytweening==1.2.0
 win32-setctime==1.2.0
 keyboard==0.13.5
+pynput==1.7.6
+


### PR DESCRIPTION
## Summary
- add a utility to recapture templates with ctrl+click using a new `template_recorder` module
- hook F12 hotkey in the menu to start template recapture
- adjust ESC handling so F12 mode can exit without closing the app
- include new dependency `pynput` in requirements and pyproject

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686b85e9d594833297f78211b11d5651